### PR TITLE
MOD-35-Filter-table-data-to-remove-land-masked-bins

### DIFF
--- a/tests/testthat/test-MODISR_AQUA.R
+++ b/tests/testthat/test-MODISR_AQUA.R
@@ -303,6 +303,8 @@ test <- modisr_aqua_read_data_from_folder(target_folder, is_binned = TRUE, bound
 
 
 
+
+
   })
 
 })
@@ -331,3 +333,31 @@ describe("land_mask",{
   })
 
 })
+
+
+describe("modisr_binned_to_sf",{
+
+  it("should return an sf object for the data",{
+
+
+    connection <- RNetCDF::open.nc(here::here("tests/testthat/data/AQUA_MODIS.20230701.L3b.DAY.SST.nc"))
+
+    on.exit(RNetCDF::close.nc(connection))
+
+    n_lat  <- 44
+    s_lat <- 42
+    w_lon <- -10
+    e_lon <- -8
+
+    test_data <- modisr_aqua_read_vars(connection, is_binned = TRUE, bounding_box = list(n_lat = n_lat, s_lat = s_lat, w_lon = w_lon, e_lon = e_lon))
+
+    test <- modisr_binned_to_sf(test_data)
+
+
+
+    expect_snapshot_value(test, style = "serialize")
+
+  })
+
+})
+


### PR DESCRIPTION
Remove land pixels when reading data

Functions updated:

- modisr_aqua_read_file_vars
- modisr_aqua_read_data_from_folder
- modisr_aqua_read_vars

Auxiliary functions implemented:
- modisr_binned_to_sf